### PR TITLE
replaceSpan receiver为Spannable时, 在非文字替换的情况下, 保持原有引用

### DIFF
--- a/app/src/main/java/com/drake/spannable/sample/MainActivity.kt
+++ b/app/src/main/java/com/drake/spannable/sample/MainActivity.kt
@@ -87,7 +87,7 @@ class MainActivity : AppCompatActivity() {
                 ColorSpan("#ed6a2c")
             }.replaceSpanFirst("[\\d\\.]+".toRegex()) { // 匹配价格字号
                 AbsoluteSizeSpan(18, true)
-            }.addSpan("image", CenterImageSpan(this, R.drawable.ic_launcher_round).setDrawableSize(80, 80)) // 设置一个80像素宽高的图标
+            }.addSpan("image", CenterImageSpan(this, R.mipmap.ic_launcher_round).setDrawableSize(80, 80)) // 设置一个80像素宽高的图标
     }
 }
 

--- a/spannable/src/main/java/com/drake/spannable/SpanUtils.kt
+++ b/spannable/src/main/java/com/drake/spannable/SpanUtils.kt
@@ -138,7 +138,7 @@ fun CharSequence.addSpan(where: Int, text: CharSequence, what: Any? = null, flag
  * 3. 返回[android.text.Spanned]可以替换字符串同时添加Span效果.
  * 4. 返回[kotlin.CharSequence]则仅仅是替换字符串.
  * 5. 并且本函数支持反向引用捕获组, 使用方法等同于RegEx: $捕获组索引
- * 6. 和[replace]函数不同的时本函数会保留原有[android.text.Spanned]的效果
+ * 6. 和[replace]函数不同的是本函数会保留原有[android.text.Spanned]的效果
  *
  * @return 如果没有匹配任何项会返回原来的[CharSequence]
  */
@@ -163,7 +163,7 @@ fun CharSequence.replaceSpan(oldValue: String, ignoreCase: Boolean = false, repl
  * 3. 返回[android.text.Spanned]可以替换字符串同时添加Span效果.
  * 4. 返回[kotlin.CharSequence]则仅仅是替换字符串.
  * 5. 并且本函数支持反向引用捕获组, 使用方法等同于RegEx: $捕获组索引
- * 6. 和[replace]函数不同的时本函数会保留原有[android.text.Spanned]的效果
+ * 6. 和[replace]函数不同的是本函数会保留原有[android.text.Spanned]的效果
  *
  * @return 如果没有匹配任何项会返回原来的[CharSequence]
  */
@@ -229,7 +229,7 @@ fun CharSequence.replaceSpan(regex: Regex, quoteGroup: Boolean = false, replacem
  * 3. 返回[android.text.Spanned]可以替换字符串同时添加Span效果.
  * 4. 返回[kotlin.CharSequence]则仅仅是替换字符串.
  * 5. 并且本函数支持反向引用捕获组, 使用方法等同于RegEx: $捕获组索引
- * 6. 和[replace]函数不同的时本函数会保留原有[android.text.Spanned]的效果
+ * 6. 和[replace]函数不同的是本函数会保留原有[android.text.Spanned]的效果
  *
  * @return 如果没有匹配任何项会返回原来的[CharSequence]
  */
@@ -254,7 +254,7 @@ fun CharSequence.replaceSpanFirst(oldValue: String, ignoreCase: Boolean = false,
  * 3. 返回[android.text.Spanned]可以替换字符串同时添加Span效果.
  * 4. 返回[kotlin.CharSequence]则仅仅是替换字符串.
  * 5. 并且本函数支持反向引用捕获组, 使用方法等同于RegEx: $捕获组索引
- * 6. 和[replace]函数不同的时本函数会保留原有[android.text.Spanned]的效果
+ * 6. 和[replace]函数不同的是本函数会保留原有[android.text.Spanned]的效果
  *
  * @return 如果没有匹配任何项会返回原来的[CharSequence]
  */
@@ -317,7 +317,7 @@ fun CharSequence.replaceSpanFirst(regex: Regex, quoteGroup: Boolean = false, rep
  * 3. 返回[android.text.Spanned]可以替换字符串同时添加Span效果.
  * 4. 返回[kotlin.CharSequence]则仅仅是替换字符串.
  * 5. 并且本函数支持反向引用捕获组, 使用方法等同于RegEx: $捕获组索引
- * 6. 和[replace]函数不同的时本函数会保留原有[android.text.Spanned]的效果
+ * 6. 和[replace]函数不同的是本函数会保留原有[android.text.Spanned]的效果
  *
  * @return 如果没有匹配任何项会返回原来的[CharSequence]
  */
@@ -342,7 +342,7 @@ fun CharSequence.replaceSpanLast(oldValue: String, ignoreCase: Boolean = false, 
  * 3. 返回[android.text.Spanned]可以替换字符串同时添加Span效果.
  * 4. 返回[kotlin.CharSequence]则仅仅是替换字符串.
  * 5. 并且本函数支持反向引用捕获组, 使用方法等同于RegEx: $捕获组索引
- * 6. 和[replace]函数不同的时本函数会保留原有[android.text.Spanned]的效果
+ * 6. 和[replace]函数不同的是本函数会保留原有[android.text.Spanned]的效果
  *
  * @return 如果没有匹配任何项会返回原来的[CharSequence]
  */

--- a/spannable/src/main/java/com/drake/spannable/SpanUtils.kt
+++ b/spannable/src/main/java/com/drake/spannable/SpanUtils.kt
@@ -169,7 +169,7 @@ fun CharSequence.replaceSpan(oldValue: String, ignoreCase: Boolean = false, repl
  */
 @JvmOverloads
 fun CharSequence.replaceSpan(regex: Regex, quoteGroup: Boolean = false, replacement: (MatchResult) -> Any?): CharSequence {
-    val spanBuilder = SpannableStringBuilder(this)
+    var spanBuilder = if (this is Spannable) this else SpannableStringBuilder(this)
     var offset = 0
     regex.findAll(this).forEach { matchResult ->
         val range = matchResult.range
@@ -205,7 +205,10 @@ fun CharSequence.replaceSpan(regex: Regex, quoteGroup: Boolean = false, replacem
                         }
                     }
                     val matchLength = matchResult.value.length
-                    spanBuilder.replace(range.first + offset, range.first + offset + matchLength, adjustReplacement)
+                    if (spanBuilder !is SpannableStringBuilder){
+                        spanBuilder = SpannableStringBuilder(spanBuilder)
+                    }
+                    (spanBuilder as SpannableStringBuilder).replace(range.first + offset, range.first + offset + matchLength, adjustReplacement)
                     offset += adjustReplacement.length - matchLength
                 }
                 else -> spanBuilder[range.first, range.last + 1] = spanned
@@ -258,7 +261,7 @@ fun CharSequence.replaceSpanFirst(oldValue: String, ignoreCase: Boolean = false,
 @JvmOverloads
 fun CharSequence.replaceSpanFirst(regex: Regex, quoteGroup: Boolean = false, replacement: (MatchResult) -> Any?): CharSequence {
     val matchResult = regex.find(this) ?: return this
-    val spanBuilder = SpannableStringBuilder(this)
+    var spanBuilder = if (this is Spannable) this else SpannableStringBuilder(this)
     val range = matchResult.range
     replacement(matchResult)?.let { spanned ->
         when (spanned) {
@@ -292,7 +295,10 @@ fun CharSequence.replaceSpanFirst(regex: Regex, quoteGroup: Boolean = false, rep
                     }
                 }
                 val matchLength = matchResult.value.length
-                spanBuilder.replace(range.first, range.first + matchLength, adjustReplacement)
+                if (spanBuilder !is SpannableStringBuilder){
+                    spanBuilder = SpannableStringBuilder(spanBuilder)
+                }
+                (spanBuilder as SpannableStringBuilder).replace(range.first, range.first + matchLength, adjustReplacement)
             }
             else -> spanBuilder[range.first, range.last + 1] = spanned
         }
@@ -343,7 +349,7 @@ fun CharSequence.replaceSpanLast(oldValue: String, ignoreCase: Boolean = false, 
 @JvmOverloads
 fun CharSequence.replaceSpanLast(regex: Regex, quoteGroup: Boolean = false, replacement: (MatchResult) -> Any?): CharSequence {
     val matchResult = regex.findAll(this).lastOrNull() ?: return this
-    val spanBuilder = SpannableStringBuilder(this)
+    var spanBuilder = if (this is Spannable) this else SpannableStringBuilder(this)
     val range = matchResult.range
     replacement(matchResult)?.let { spanned ->
         when (spanned) {
@@ -377,7 +383,10 @@ fun CharSequence.replaceSpanLast(regex: Regex, quoteGroup: Boolean = false, repl
                     }
                 }
                 val matchLength = matchResult.value.length
-                spanBuilder.replace(range.first, range.first + matchLength, adjustReplacement)
+                if (spanBuilder !is SpannableStringBuilder){
+                    spanBuilder = SpannableStringBuilder(spanBuilder)
+                }
+                (spanBuilder as SpannableStringBuilder).replace(range.first, range.first + matchLength, adjustReplacement)
             }
             else -> spanBuilder[range.first, range.last + 1] = spanned
         }


### PR DESCRIPTION
原代码在在处理需保持原有引用的Spannable时（如`Editable`），每次`replaceSpan`后，都会生成新的对象，导致只有第一个replaceSpan生效。