### PR TITLE
fix: 禁止重复设置相同Span类 (#19)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 </p>
 
 <p align="center">
-<a href="https://github.com/liangjingkanji/spannable/releases/download/1.2.3/spannale-sample.apk">下载体验</a>
+<a href="https://github.com/liangjingkanji/spannable/releases/download/1.2.4/spannale-sample.apk">下载体验</a>
 </p>
 
 <br>
@@ -33,6 +33,7 @@
 - [x] 没有自定义控件/没有多余函数
 - [x] 快速实现图文混排/富文本/自定义表情包
 - [x] 输入框富文本/表情包
+- [x] 可监听剪贴板粘贴/手动输入文本渲染
 
 ## 函数
 
@@ -90,7 +91,7 @@ dependencyResolutionManagement {
 然后在 module 的 build.gradle 添加依赖框架
 
 ```groovy
-implementation 'com.github.liangjingkanji:spannable:1.2.3'
+implementation 'com.github.liangjingkanji:spannable:1.2.4'
 ```
 
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -73,4 +73,6 @@ dependencies {
 
     implementation "com.github.bumptech.glide:glide:4.11.0"
     implementation 'com.github.liangjingkanji:Engine:0.0.61'
+
+    implementation 'com.github.liangjingkanji:debugkit:1.3.0'
 }

--- a/app/src/main/java/com/drake/spannable/sample/RichInputActivity.kt
+++ b/app/src/main/java/com/drake/spannable/sample/RichInputActivity.kt
@@ -20,6 +20,7 @@ import android.graphics.Typeface
 import android.os.Bundle
 import android.text.Editable
 import com.drake.engine.utils.dp
+import com.drake.spannable.addSpan
 import com.drake.spannable.listener.ModifyTextWatcher
 import com.drake.spannable.replaceSpan
 import com.drake.spannable.sample.base.BaseMenuActivity
@@ -30,6 +31,9 @@ import com.drake.spannable.span.HighlightSpan
 class RichInputActivity : BaseMenuActivity() {
 
     private val binding by lazy { ActivityRichInputBinding.inflate(layoutInflater) }
+
+    private val inputContent // 输入框内容
+        get() = binding.etInput.text
 
     // 匹配规则, 因为同一个Span对象重复设置仅最后一个有效故每次都得创建新的对象
     private val matchRules = mapOf<Regex, (MatchResult) -> Any?>(
@@ -52,5 +56,15 @@ class RichInputActivity : BaseMenuActivity() {
                 }
             }
         })
+
+        // 点击插入表情
+        binding.ivAngry.setOnClickListener {
+            binding.etInput.setText(inputContent addSpan "生气")
+            binding.etInput.setSelection(inputContent.length)
+        }
+        binding.ivHappy.setOnClickListener {
+            binding.etInput.setText(inputContent addSpan "开心")
+            binding.etInput.setSelection(inputContent.length)
+        }
     }
 }

--- a/app/src/main/res/layout/activity_rich_input.xml
+++ b/app/src/main/res/layout/activity_rich_input.xml
@@ -10,13 +10,32 @@
     <EditText
         android:id="@+id/etInput"
         android:layout_width="match_parent"
-        android:layout_height="150dp"
+        android:layout_height="300dp"
         android:gravity="left|bottom" />
 
 
     <TextView
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:text="请输入 @用户 #标签 或者 开心 happy 生气 蚂蚁 等词语" />
+        android:layout_height="wrap_content"
+        android:text="支持剪切板粘贴/输入监听/设置文本\n例如 @用户 #标签 或者 开心 happy 生气 蚂蚁 等词语" />
+
+    <androidx.appcompat.widget.LinearLayoutCompat
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="20dp">
+
+        <ImageView
+            android:id="@+id/ivAngry"
+            android:layout_width="50dp"
+            android:layout_height="50dp"
+            android:src="@drawable/ic_angry" />
+
+        <ImageView
+            android:id="@+id/ivHappy"
+            android:layout_width="50dp"
+            android:layout_height="50dp"
+            android:src="@drawable/ic_happy" />
+
+    </androidx.appcompat.widget.LinearLayoutCompat>
 
 </androidx.appcompat.widget.LinearLayoutCompat>


### PR DESCRIPTION
每次设置Span之前先删除原有Span类

这里是不允许判断是否已经存在相同Span类然后不设置, 因为会涉及到对相同字符串但是长度不同设置相同Span类

比如第一次设置 `@用`  第二次设置 `@用户`, 实际上已经存在一个Span类但是依然需要设置, 这个时候只能先删除

@ccominghome